### PR TITLE
Debug logging also via yaml config

### DIFF
--- a/boneio/bonecli.py
+++ b/boneio/bonecli.py
@@ -9,8 +9,8 @@ from colorlog import ColoredFormatter
 
 from boneio.const import ACTION
 from boneio.helper import load_config_from_file
-from boneio.runner import async_run
-
+from boneio.runner import async_run, configure_logger
+from boneio.version import __version__
 
 TASK_CANCELATION_TIMEOUT = 1
 
@@ -64,12 +64,13 @@ def get_arguments() -> argparse.Namespace:
     return arguments
 
 
-def run(config: str, mqttusername: str = "", mqttpassword: str = ""):
+def run(config: str, debug: int, mqttusername: str = "", mqttpassword: str = ""):
     """Run BoneIO."""
     _LOGGER.info("BoneIO starting.")
     _config = load_config_from_file(config_file=config)
     if not _config:
         return
+    configure_logger(log_config=_config.get("logger"), debug=debug)
     return asyncio.run(
         async_run(
             config=_config,

--- a/boneio/bonecli.py
+++ b/boneio/bonecli.py
@@ -7,10 +7,10 @@ import sys
 
 from colorlog import ColoredFormatter
 
-from boneio.const import ACTION, PAHO, PYMODBUS
+from boneio.const import ACTION
 from boneio.helper import load_config_from_file
 from boneio.runner import async_run
-from boneio.version import __version__
+
 
 TASK_CANCELATION_TIMEOUT = 1
 
@@ -85,24 +85,14 @@ def main() -> int:
 
     args = get_arguments()
     debug = args.debug
-    if debug == 0:
-        logging.getLogger().setLevel(logging.INFO)
-    if debug > 0:
-        logging.getLogger().setLevel(logging.DEBUG)
-        _LOGGER.info("Debug mode active")
-        _LOGGER.debug(f"Lib version is {__version__}")
-    if debug > 1:
-        logging.getLogger(PAHO).setLevel(logging.DEBUG)
-        logging.getLogger(PYMODBUS).setLevel(logging.DEBUG)
-        logging.getLogger("pymodbus.client").setLevel(logging.DEBUG)
-    else:
-        logging.getLogger(PAHO).setLevel(logging.WARN)
+
     exit_code = 0
     if args.action == "run":
         exit_code = run(
             config=args.config,
             mqttusername=args.mqttusername,
             mqttpassword=args.mqttpassword,
+            debug=debug,
         )
 
     return exit_code

--- a/boneio/const.py
+++ b/boneio/const.py
@@ -24,7 +24,6 @@ GPIO = "gpio"
 GPIO_MODE = "gpio_mode"
 ACTIONS = "actions"
 ACTION = "action"
-ACTION_TYPE = "action_type"
 OUTPUT = "output"
 SWITCH = "switch"
 CONFIG_PIN = "/usr/bin/config-pin"
@@ -54,7 +53,6 @@ SECOND_DELAY_DURATION = 0.3
 # HA CONSTS
 HOMEASSISTANT = "homeassistant"
 HA_DISCOVERY = "ha_discovery"
-HA_TYPE = "ha_type"
 OUTPUT_TYPE = "output_type"
 SHOW_HA = "show_in_ha"
 

--- a/boneio/manager.py
+++ b/boneio/manager.py
@@ -7,7 +7,6 @@ from busio import I2C
 
 from boneio.const import (
     ACTION,
-    ACTION_TYPE,
     BONEIO,
     CLOSE,
     COVER,

--- a/boneio/schema/schema.yaml
+++ b/boneio/schema/schema.yaml
@@ -59,7 +59,7 @@ logger:
       meta:
         label: Module which you want logger to set. Default for app logger.
     logs:
-      type: list
+      type: dict
       meta:
         label: List of dict module\:level.
       

--- a/boneio/schema/schema.yaml
+++ b/boneio/schema/schema.yaml
@@ -48,6 +48,23 @@ mqtt:
           meta:
             label: Prefix topic of HA discovery.
 
+logger:
+  type: dict
+  required: False
+  schema:
+    default:
+      type: string
+      required: False
+      allowed: ["critical", "error", "warning", "info", "debug"]
+      meta:
+        label: Module which you want logger to set. Default for app logger.
+    logs:
+      type: list
+      meta:
+        label: List of dict module\:level.
+      
+
+
 oled:
   type: dict
   default: {}


### PR DESCRIPTION
Now user can configure logging also via `yaml`

eg
```yaml
logger:
  default: debug
  logs:
    paho.mqtt.client: info
```