### PR TITLE
Prevent relay flickering on startup

### DIFF
--- a/boneio/relay/mcp.py
+++ b/boneio/relay/mcp.py
@@ -24,7 +24,7 @@ class MCPRelay(BasicRelay):
     ) -> None:
         """Initialize MCP relay."""
         self._pin: DigitalInOut = mcp.get_pin(pin)
-        self._pin.switch_to_output(value=True)
+        self._pin.switch_to_output(value=False)
         if output_type == NONE:
             """Just in case to not restore state of covers etc."""
             restored_state = False

--- a/boneio/relay/mcp.py
+++ b/boneio/relay/mcp.py
@@ -24,11 +24,10 @@ class MCPRelay(BasicRelay):
     ) -> None:
         """Initialize MCP relay."""
         self._pin: DigitalInOut = mcp.get_pin(pin)
-        self._pin.switch_to_output(value=False)
         if output_type == NONE:
             """Just in case to not restore state of covers etc."""
             restored_state = False
-        self._pin.value = restored_state
+        self._pin.switch_to_output(value=restored_state)
         super().__init__(
             **kwargs, output_type=output_type, restored_state=restored_state
         )


### PR DESCRIPTION
Set MCP pin output value on init to LOW - instead of HIGH.

When the value is HIGH on init it causes relay flickering on startup as on the attached video

https://user-images.githubusercontent.com/142751/170858199-7f00464d-bdfe-40af-ba8d-cd024803d287.mov
