### PR TITLE
Fix output32x5A example config MCP pins

### DIFF
--- a/boneio/example_config/output32x5A.yaml
+++ b/boneio/example_config/output32x5A.yaml
@@ -131,7 +131,7 @@
 - id: OUT_22
   kind: mcp
   mcp_id: mcp1
-  pin: 13
+  pin: 10
   output_type: light
 
 - id: OUT_23
@@ -157,7 +157,7 @@
 - id: OUT_26
   kind: mcp
   mcp_id: mcp2
-  pin: 9
+  pin: 14
   output_type: light
 
 - id: OUT_27
@@ -193,5 +193,5 @@
 - id: OUT_32
   kind: mcp
   mcp_id: mcp2
-  pin: 15
+  pin: 8
   output_type: light


### PR DESCRIPTION
These changes were previously in [commit](https://github.com/boneIO-eu/app_bbb/commit/fd8df9d31cf7911c8eea1855240c589bc58a3801), but probably was reverted accidentally with [merge commit](https://github.com/boneIO-eu/app_bbb/commit/87f882e600e57ef8bc7c2560294c59ffa8075436).