### PR TITLE
Support for ADC sensor filters

### DIFF
--- a/boneio/helper/loader.py
+++ b/boneio/helper/loader.py
@@ -94,6 +94,7 @@ def create_adc(manager: Manager, topic_prefix: str, adc_list: list = []):
                 send_message=manager.send_message,
                 topic_prefix=topic_prefix,
                 update_interval=gpio.get(UPDATE_INTERVAL, TimePeriod(seconds=60)),
+                filters=gpio.get(FILTERS, []),
             )
             if gpio.get(SHOW_HA, True):
                 manager.send_ha_autodiscovery(

--- a/boneio/schema/schema.yaml
+++ b/boneio/schema/schema.yaml
@@ -417,6 +417,7 @@ adc:
         default: True
         meta:
           label: If you want you can disable discovering this input in HA.
+      filters: !include filters_adc.yaml
 cover:
   type: list
   required: False

--- a/boneio/sensor/adc.py
+++ b/boneio/sensor/adc.py
@@ -26,11 +26,12 @@ def initialize_adc():
 class GpioADCSensor(BasicMqtt, AsyncUpdater, Filter):
     """Represent Gpio ADC sensor."""
 
-    def __init__(self, pin: str, **kwargs) -> None:
+    def __init__(self, pin: str, filters: list, **kwargs) -> None:
         """Setup GPIO ADC Sensor"""
         super().__init__(topic_type=SENSOR, **kwargs)
         self._pin = pin
         self._state = None
+        self._filters = filters
         AsyncUpdater.__init__(self, **kwargs)
         _LOGGER.debug("Configured sensor pin %s", self._pin)
 


### PR DESCRIPTION
Previously, filters weren't passed from the config to `boneio.sensor.GpioADCSensor`, even though the class has already inherited from `Filter` and has been using it's method. Also the file `boneio/schema/filter_adc.yaml` wasn't referenced anywhere, not allowing ADC sensor filters to load from config files. These little changes address it.