### PR TITLE
Fix max long press duration

### DIFF
--- a/frontend/src/components/UISettings/EventForm.tsx
+++ b/frontend/src/components/UISettings/EventForm.tsx
@@ -790,10 +790,10 @@ const EventForm: React.FC<EventFormProps> = ({
             <div className="form-control">
               <SimpleTimePeriodInput
                 label={t('event_form.max_long_press_duration')}
-                value={data.max_long_press_duration || '120s'}
+                value={data.max_long_press_duration ?? '120s'}
                 onChange={(value) => updateField('max_long_press_duration', value)}
-                maximum={600}
-                allowedUnits={['s']}
+                maximum={600000}
+                allowedUnits={['s', 'ms']}
               />
               <label className="label">
                 <span className="label-text-alt">{t('event_form.max_long_press_duration_hint')} ({t('common.default')}: 120s)</span>


### PR DESCRIPTION
Due to the maximum value being too low, the Max Long Press Duration field could not be edited. I also added the ability to enter milliseconds. I also changed the value reading logic so that 0 in yaml is 0 in the gui.